### PR TITLE
Add verbose flag

### DIFF
--- a/lib/releasecop.rb
+++ b/lib/releasecop.rb
@@ -2,6 +2,8 @@ require "releasecop/version"
 require 'thor'
 require 'shellwords'
 require 'json'
+require "releasecop/comparison"
+require "releasecop/result"
 require "releasecop/checker"
 require "releasecop/cli"
 

--- a/lib/releasecop/checker.rb
+++ b/lib/releasecop/checker.rb
@@ -7,31 +7,33 @@ module Releasecop
       self.envs = envs
     end
 
-    # Reports status of individual project. Returns count of out-of-date environments.
     def check
-      puts "#{name}..."
-      unreleased = 0
       Dir.chdir(CONFIG_DIR) do
         `git clone #{envs.first['git']} --bare #{name} > /dev/null 2>&1`
+
         Dir.chdir(name) do
           envs.each do |env|
             `git remote add #{env['name']} #{env['git']} > /dev/null 2>&1`
             `git fetch #{env['name']} > /dev/null 2>&1`
           end
+
+          comparisons = []
           envs.each_cons(2) do |ahead, behind|
-            log = `git log #{behind['name']}/#{behind['branch'] || 'master'}..#{ahead['name']}/#{ahead['branch'] || 'master'} --pretty=format:"%h %ad %s (%an)" --date=short --no-merges`
-            if log == ''
-              puts "  #{behind['name']} is up-to-date with #{ahead['name']}\n"
-            else
-              puts "  #{behind['name']} is behind #{ahead['name']} by:"
-              log.lines.each { |l| puts "    #{l}" }
-              unreleased += 1
-            end
+            comparisons << Comparison.new(ahead, behind)
           end
+
+          comparisons.each &:check
+          @result = Result.new(name, comparisons)
         end
       end
-      unreleased
     end
 
+    def message
+      @result.message
+    end
+
+    def unreleased
+      @result.unreleased
+    end
   end
 end

--- a/lib/releasecop/checker.rb
+++ b/lib/releasecop/checker.rb
@@ -28,8 +28,8 @@ module Releasecop
       end
     end
 
-    def message
-      @result.message
+    def puts_message(verbose_flag)
+      @result.puts_message(verbose_flag)
     end
 
     def unreleased

--- a/lib/releasecop/cli.rb
+++ b/lib/releasecop/cli.rb
@@ -26,7 +26,7 @@ module Releasecop
 
       for checker in checkers
         checker.check
-        puts checker.message
+        checker.puts_message(options[:verbose])
       end
 
       unreleased = checkers.map(&:unreleased).inject(&:+)

--- a/lib/releasecop/cli.rb
+++ b/lib/releasecop/cli.rb
@@ -22,11 +22,14 @@ module Releasecop
       selected = options[:all] ? manifest['projects'] : manifest['projects'].select{|k,v| k == project }
       raise Thor::Error, "No projects found." if selected.empty?
 
-      unreleased = 0
-      selected.each do |name, envs|
-        unreleased += Releasecop::Checker.new(name, envs).check
+      checkers = selected.map { |name, envs| Releasecop::Checker.new(name, envs) }
+
+      for checker in checkers
+        checker.check
+        puts checker.message
       end
 
+      unreleased = checkers.map(&:unreleased).inject(&:+)
       $stderr.puts "#{selected.size} project(s) checked. #{unreleased} environment(s) out-of-date."
       exit 1 if unreleased > 0
     end

--- a/lib/releasecop/comparison.rb
+++ b/lib/releasecop/comparison.rb
@@ -1,0 +1,62 @@
+class Comparison
+  attr_accessor :lines
+
+  def initialize(ahead, behind)
+    @ahead = ahead
+    @behind = behind
+  end
+
+  def check
+    @lines = log.lines
+  end
+
+  def message
+    [summary_message, *detail_messages].join
+  end
+
+  def unreleased?
+    !lines.empty?
+  end
+
+  private
+
+  def log
+    `git log #{from_rev}..#{to_rev} --pretty=format:"%h %ad %s (%an)" --date=short --no-merges`
+  end
+
+  def from_rev
+    [behind_name, behind_branch].join '/'
+  end
+
+  def to_rev
+    [ahead_name, ahead_branch].join '/'
+  end
+
+  def behind_name
+    @behind['name']
+  end
+
+  def behind_branch
+    @behind['branch'] || 'master'
+  end
+
+  def ahead_name
+    @ahead['name']
+  end
+
+  def ahead_branch
+    @ahead['branch'] || 'master'
+  end
+
+  def summary_message
+    if unreleased?
+      "  #{behind_name} is behind #{ahead_name} by:\n"
+    else
+      "  #{behind_name} is up-to-date with #{ahead_name}"
+    end
+  end
+
+  def detail_messages
+    lines.map { |l| "    #{l}" }
+  end
+end

--- a/lib/releasecop/result.rb
+++ b/lib/releasecop/result.rb
@@ -4,8 +4,12 @@ class Result
     @comparisons = comparisons
   end
 
-  def message
-    [header, *comparison_messages].join "\n"
+  def puts_message(verbose_flag)
+    if verbose_flag
+      puts message
+    else
+      puts message if unreleased?
+    end
   end
 
   def unreleased
@@ -14,8 +18,16 @@ class Result
 
   private
 
+  def message
+    [header, *comparison_messages].join "\n"
+  end
+
   def header
     "#{@name}..."
+  end
+
+  def unreleased?
+    unreleased > 0
   end
 
   def comparison_messages

--- a/lib/releasecop/result.rb
+++ b/lib/releasecop/result.rb
@@ -1,0 +1,24 @@
+class Result
+  def initialize(name, comparisons)
+    @name = name
+    @comparisons = comparisons
+  end
+
+  def message
+    [header, *comparison_messages].join "\n"
+  end
+
+  def unreleased
+    @comparisons.select(&:unreleased?).count
+  end
+
+  private
+
+  def header
+    "#{@name}..."
+  end
+
+  def comparison_messages
+    @comparisons.map &:message
+  end
+end


### PR DESCRIPTION
I have a hard time with the output of releasecop because it's so noisy. I had the idea to introduce a flag called `verbose` that would keep the existing behavior and then when that flag is not given, only the projects that are out of date are shown. I think that would help make the email that's generated even more useful.

In my quest to do this, I refactored the heck out of this thing so that I could make [the easy change](https://twitter.com/kentbeck/status/250733358307500032). Thus, the first commit is huge and the second commit is simple.

Since there aren't any tests, I sorta just relied on running it and getting the same output as master, haha. If I wasn't so lazy, I guess I could have added some specs, but I am lazy. Plus, now there's even more room for improvement and contributions from others!! 🎉 

My hope is that you'll merge this PR and then leave Jenkins alone so that the email is nice and trim - just the projects that need attention. My other hope is that you like this direction! 😄  ❤️ 