### PR TITLE
Add support for Hokusai (Take II)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,23 @@ To check all projects:
 
 At this time releasecop is not compatible with projects using [Heroku Pipelines](https://devcenter.heroku.com/articles/pipelines) to promote apps. For these apps, promoting a staging app to production simply copies the slug to the production app, so no git remote is updated.
 
+### Hokusai Pipelines
+[Hokusai](https://github.com/artsy/hokusai) is a tool developed by Artsy's engineering used for managing apps on [Kubernetes](https://kubernetes.io/). Releasecop supports Hokusai-based apps. In order for this to work, you need to make sure Hokusai is installed on the machine running releasecop by:
+```shell
+brew install hokusai
+```
+You also need to make sure Hokusai is setup properly on that machine and has access to ECR by following setup steps on Hokusai.
+In order to make an app enabled for hokusai check, make sure that in your manifest file when you define an environment, also mention what image tag this deployment uses on K8s. For example in following `manifest.json` example:
+```json
+# manifest.json
+{
+    "test-api": [
+      {"name": "staging", "git": "git@github.com:artsy/test-api.git", "hokusai": "staging"},
+      {"name": "production", "git": "git@github.com:artsy/test-api.git", "hokusai": "production"}
+    ]
+}
+```
+We define that our deployment has two environments, `staging` and `production` and `staging` deployment uses `staging` as image tag deployed on k8s and `production` uses `production` image tag.
+
 
 Copyright (c) 2015 Joey Aghion, Artsy

--- a/lib/releasecop.rb
+++ b/lib/releasecop.rb
@@ -2,6 +2,7 @@ require "releasecop/version"
 require 'thor'
 require 'shellwords'
 require 'json'
+require 'releasecop/manifest_item'
 require "releasecop/comparison"
 require "releasecop/result"
 require "releasecop/checker"

--- a/lib/releasecop/checker.rb
+++ b/lib/releasecop/checker.rb
@@ -4,17 +4,17 @@ module Releasecop
 
     def initialize(name, envs)
       self.name = name
-      self.envs = envs
+      self.envs = envs.map { |e| ManifestItem.new(name, e) }
     end
 
     def check
       Dir.chdir(CONFIG_DIR) do
-        `git clone #{envs.first['git']} --bare #{name} > /dev/null 2>&1`
+        `git clone #{envs.first.git} --bare #{name} > /dev/null 2>&1`
 
         Dir.chdir(name) do
           envs.each do |env|
-            `git remote add #{env['name']} #{env['git']} > /dev/null 2>&1`
-            `git fetch #{env['name']} > /dev/null 2>&1`
+            `git remote add #{env.name} #{env.git} > /dev/null 2>&1`
+            `git fetch #{env.name} > /dev/null 2>&1`
           end
 
           comparisons = []

--- a/lib/releasecop/checker.rb
+++ b/lib/releasecop/checker.rb
@@ -9,7 +9,7 @@ module Releasecop
 
     def check
       Dir.chdir(CONFIG_DIR) do
-        `git clone #{envs.first.git} --bare #{name} > /dev/null 2>&1`
+        `git clone #{envs.first.git} #{envs.first.hokusai_tag ? '' : '--bare'} #{name} > /dev/null 2>&1`
 
         Dir.chdir(name) do
           envs.each do |env|

--- a/lib/releasecop/comparison.rb
+++ b/lib/releasecop/comparison.rb
@@ -1,5 +1,5 @@
 class Comparison
-  attr_accessor :lines
+  attr_accessor :lines, :behind, :ahead
 
   def initialize(ahead, behind)
     @ahead = ahead
@@ -10,10 +10,6 @@ class Comparison
     @lines = log.lines
   end
 
-  def message
-    [summary_message, *detail_messages].join
-  end
-
   def unreleased?
     !lines.empty?
   end
@@ -21,42 +17,6 @@ class Comparison
   private
 
   def log
-    `git log #{from_rev}..#{to_rev} --pretty=format:"%h %ad %s (%an)" --date=short --no-merges`
-  end
-
-  def from_rev
-    [behind_name, behind_branch].join '/'
-  end
-
-  def to_rev
-    [ahead_name, ahead_branch].join '/'
-  end
-
-  def behind_name
-    @behind['name']
-  end
-
-  def behind_branch
-    @behind['branch'] || 'master'
-  end
-
-  def ahead_name
-    @ahead['name']
-  end
-
-  def ahead_branch
-    @ahead['branch'] || 'master'
-  end
-
-  def summary_message
-    if unreleased?
-      "  #{behind_name} is behind #{ahead_name} by:\n"
-    else
-      "  #{behind_name} is up-to-date with #{ahead_name}"
-    end
-  end
-
-  def detail_messages
-    lines.map { |l| "    #{l}" }
+    `git log #{@ahead.for_rev_range}..#{@behind.for_rev_range} --pretty=format:"%h %ad %s (%an)" --date=short --no-merges`
   end
 end

--- a/lib/releasecop/manifest_item.rb
+++ b/lib/releasecop/manifest_item.rb
@@ -1,5 +1,5 @@
 class ManifestItem
-  attr_reader :git, :branch, :name
+  attr_reader :git, :branch, :name, :hokusai_tag
 
   def initialize(repo_name, item)
     @repo_name = repo_name
@@ -7,11 +7,11 @@ class ManifestItem
     @name = item['name']
     @branch = item['branch'] || 'master'
     @hokusai_tag = item['hokusai']
-    @sha = find_hokusai_sha if @hokusai_tag
   end
 
   def for_rev_range
-    @sha || [@name, @branch].join('/')
+    sha = find_hokusai_sha if @hokusai_tag
+    sha || [@name, @branch].join('/')
   end
 
   private
@@ -21,17 +21,8 @@ class ManifestItem
   end
 
   def find_hokusai_sha
-    # @TODO: hokusai expects `hokusai/config.yaml` to be there to work
-    # for that we need to clone the app again with actual code and cannot use
-    # bare clone of repo, we maybe able to avoid this.
-    Dir.chdir(Releasecop::CONFIG_DIR) do
-      `git clone #{@git} #{working_dir} > /dev/null 2>&1`
-      Dir.chdir(working_dir) do
-        images_output = `hokusai registry images`
-        tags = images_output.lines.grep(/\d{4}.* | .* | .*/).map{|l| l.split(' | ').last.split(',').map(&:strip)}
-        tags.detect{|t| t.include?(@hokusai_tag) }.detect{|t| t[/^[0-9a-f]{40}$/]}
-      end
-    end
+    images_output = `hokusai registry images`
+    tags = images_output.lines.grep(/\d{4}.* | .* | .*/).map{|l| l.split(' | ').last.split(',').map(&:strip)}
+    tags.detect{|t| t.include?(@hokusai_tag) }.detect{|t| t[/^[0-9a-f]{40}$/]}
   end
-
 end

--- a/lib/releasecop/manifest_item.rb
+++ b/lib/releasecop/manifest_item.rb
@@ -1,0 +1,37 @@
+class ManifestItem
+  attr_reader :git, :branch, :name
+
+  def initialize(repo_name, item)
+    @repo_name = repo_name
+    @git = item['git']
+    @name = item['name']
+    @branch = item['branch'] || 'master'
+    @hokusai_tag = item['hokusai']
+    @sha = find_hokusai_sha if @hokusai_tag
+  end
+
+  def for_rev_range
+    @sha || [@name, @branch].join('/')
+  end
+
+  private
+
+  def working_dir
+    "#{@repo_name}-#{@name}-working"
+  end
+
+  def find_hokusai_sha
+    # @TODO: hokusai expects `hokusai/config.yaml` to be there to work
+    # for that we need to clone the app again with actual code and cannot use
+    # bare clone of repo, we maybe able to avoid this.
+    Dir.chdir(Releasecop::CONFIG_DIR) do
+      `git clone #{@git} #{working_dir} > /dev/null 2>&1`
+      Dir.chdir(working_dir) do
+        images_output = `hokusai registry images`
+        tags = images_output.lines.grep(/\d{4}.* | .* | .*/).map{|l| l.split(' | ').last.split(',').map(&:strip)}
+        tags.detect{|t| t.include?(@hokusai_tag) }.detect{|t| t[/^[0-9a-f]{40}$/]}
+      end
+    end
+  end
+
+end

--- a/lib/releasecop/manifest_item.rb
+++ b/lib/releasecop/manifest_item.rb
@@ -10,8 +10,8 @@ class ManifestItem
   end
 
   def for_rev_range
-    sha = find_hokusai_sha if @hokusai_tag
-    sha || [@name, @branch].join('/')
+    @sha ||= find_hokusai_sha if @hokusai_tag
+    @sha || [@name, @branch].join('/')
   end
 
   private

--- a/lib/releasecop/result.rb
+++ b/lib/releasecop/result.rb
@@ -31,6 +31,14 @@ class Result
   end
 
   def comparison_messages
-    @comparisons.map &:message
+    @comparisons.map do |comparison|
+      summary = if comparison.unreleased?
+        "  #{comparison.behind.name} is behind #{comparison.ahead.name} by:\n"
+      else
+        "  #{comparison.behind.name} is up-to-date with #{comparison.ahead.name}"
+      end
+      detailed_messages = comparison.lines.map { |l| "    #{l}" }
+      [summary, *detailed_messages].join
+    end
   end
 end

--- a/releasecop.gemspec
+++ b/releasecop.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "byebug"
 end


### PR DESCRIPTION
# Problem
Add releasecop support for [Hokusai](https://github.com/artsy/hokusai)-based apps.

# Solution
Added new `ManifestItem` class which is used to parse items we get in our manifest file. For hokusai-based apps we need to add new `hokusai` tag to manifest which tells us whats the tag deployed on this specific item.
The tricky part is, we do a `git clone --bare` when checking out the project from github which does not include actual source files. This is problematic for hokusai based apps since `hokusai` cli [checks](https://github.com/artsy/hokusai/blob/master/hokusai/lib/config.py#L28) for existence of `hokusai/config.yaml` in current directory, in order to fix that, only for hokusai-based apps, we do a complete clone of the app and we run hokusai command from there.
Another tricky thing here was, for hokusai based apps we use git sha to compare branches and see whats left to deploy, for that to work we had to make sure our `git log` command doesn't include `remote` name.

Also as part of this did some other refactors:
- Moved message creation completely to `result.rb` this way `comparison` purely deals with comparing.